### PR TITLE
priority_sema added

### DIFF
--- a/include/threads/synch.h
+++ b/include/threads/synch.h
@@ -3,6 +3,8 @@
 
 #include <list.h>
 #include <stdbool.h>
+#include <debug.h>
+
 
 /* A counting semaphore. */
 struct semaphore {
@@ -34,6 +36,7 @@ struct condition {
 };
 
 void cond_init (struct condition *);
+bool sema_priority_more (const struct list_elem *a_, const struct list_elem *b_, void *aux UNUSED);
 void cond_wait (struct condition *, struct lock *);
 void cond_signal (struct condition *, struct lock *);
 void cond_broadcast (struct condition *, struct lock *);

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -127,7 +127,7 @@ typedef void thread_func (void *aux);
 tid_t thread_create (const char *name, int priority, thread_func *, void *);
 
 void thread_block (void);
-static bool priority_more (const struct list_elem *a_, const struct list_elem *b_, void *aux UNUSED);
+bool priority_more (const struct list_elem *a_, const struct list_elem *b_, void *aux UNUSED);
 void thread_unblock (struct thread *);
 
 struct thread *thread_current (void);

--- a/tests/threads/mlfqs/Make.tests
+++ b/tests/threads/mlfqs/Make.tests
@@ -19,4 +19,4 @@ tests/threads/mlfqs/mlfqs-nice-10.output		\
 tests/threads/mlfqs/mlfqs-block.output
 
 $(MLFQS_OUTPUTS): KERNELFLAGS += -mlfqs
-$(MLFQS_OUTPUTS): TIMEOUT = 1
+$(MLFQS_OUTPUTS): TIMEOUT = 480

--- a/tests/threads/mlfqs/Make.tests
+++ b/tests/threads/mlfqs/Make.tests
@@ -19,4 +19,4 @@ tests/threads/mlfqs/mlfqs-nice-10.output		\
 tests/threads/mlfqs/mlfqs-block.output
 
 $(MLFQS_OUTPUTS): KERNELFLAGS += -mlfqs
-$(MLFQS_OUTPUTS): TIMEOUT = 480
+$(MLFQS_OUTPUTS): TIMEOUT = 1

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -66,7 +66,7 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {
-		list_push_back (&sema->waiters, &thread_current ()->elem);
+		list_insert_ordered (&sema->waiters, &thread_current ()->elem, priority_more, NULL);
 		thread_block ();
 	}
 	sema->value--;
@@ -109,10 +109,12 @@ sema_up (struct semaphore *sema) {
 	ASSERT (sema != NULL);
 
 	old_level = intr_disable ();
-	if (!list_empty (&sema->waiters))
-		thread_unblock (list_entry (list_pop_front (&sema->waiters),
-					struct thread, elem));
+	if (!list_empty (&sema->waiters)) {
+		list_sort(&sema->waiters, priority_more, NULL);
+		thread_unblock (list_entry (list_pop_front (&sema->waiters), struct thread, elem));
+	}
 	sema->value++;
+	thread_yield();
 	intr_set_level (old_level);
 }
 
@@ -252,6 +254,17 @@ cond_init (struct condition *cond) {
 	list_init (&cond->waiters);
 }
 
+bool
+sema_priority_more (const struct list_elem *a_, const struct list_elem *b_, void *aux UNUSED) { 
+	const struct semaphore_elem *a = list_entry (a_, struct semaphore_elem, elem);
+	const struct semaphore_elem *b = list_entry (b_, struct semaphore_elem, elem);
+
+	const struct list *waiter_a = &(a->semaphore.waiters);
+	const struct list *waiter_b = &(b->semaphore.waiters);
+
+	return priority_more(list_begin(waiter_a), list_begin(waiter_b), NULL);
+}
+
 /* Atomically releases LOCK and waits for COND to be signaled by
    some other piece of code.  After COND is signaled, LOCK is
    reacquired before returning.  LOCK must be held before calling
@@ -282,7 +295,7 @@ cond_wait (struct condition *cond, struct lock *lock) {
 	ASSERT (lock_held_by_current_thread (lock));
 
 	sema_init (&waiter.semaphore, 0);
-	list_push_back (&cond->waiters, &waiter.elem);
+	list_insert_ordered (&cond->waiters, &waiter.elem, sema_priority_more, NULL);
 	lock_release (lock);
 	sema_down (&waiter.semaphore);
 	lock_acquire (lock);
@@ -302,9 +315,10 @@ cond_signal (struct condition *cond, struct lock *lock UNUSED) {
 	ASSERT (!intr_context ());
 	ASSERT (lock_held_by_current_thread (lock));
 
-	if (!list_empty (&cond->waiters))
-		sema_up (&list_entry (list_pop_front (&cond->waiters),
-					struct semaphore_elem, elem)->semaphore);
+	if (!list_empty (&cond->waiters)) {
+		list_sort(&cond->waiters, sema_priority_more, NULL);
+		sema_up (&list_entry (list_pop_front (&cond->waiters), struct semaphore_elem, elem)->semaphore);
+	}
 }
 
 /* Wakes up all threads, if any, waiting on COND (protected by

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -244,13 +244,13 @@ thread_block (void) {
 	schedule ();
 }
 
-static bool
+bool
 priority_more (const struct list_elem *a_, const struct list_elem *b_,
             void *aux UNUSED) { 
-  const struct thread *a = list_entry (a_, struct thread, elem);
-  const struct thread *b = list_entry (b_, struct thread, elem);
+	const struct thread *a = list_entry (a_, struct thread, elem);
+	const struct thread *b = list_entry (b_, struct thread, elem);
 
-  return a->priority > b->priority;
+	return a->priority > b->priority;
 }
 
 


### PR DESCRIPTION
1. `thread.h`에 정의된 `priority_more()`함수의 `static` 식별자를 삭제했습니다. 타 헤더 파일에서 재사용하기 위함입니다.
2. `synch.h`에 `sema_priority_more()` 함수를 추가했습니다. 이 파일은 condition에서 여러 개의 세마포어를 정렬하기 위해 쓰입니다.
3. sema_down, sema_up 함수의 waiter가 thread priority로 정렬되도록 수정했습니다. 정렬에 `priority_more` 함수를 사용합니다.
4. cond_wait, cond_signal 함수의 waiter가 각 세마포어의 선두 thread priority로 정렬되도록 수정했습니다. 정렬에 `sema_priority_more` 함수를 사용합니다.

![KakaoTalk_Photo_2023-11-27-22-52-03](https://github.com/KJ3-W07-09-TEAM5/pintos-kaist/assets/52403430/94002d5f-4a2e-4b25-968d-d95b4c955265)
