### PR TITLE
priority with donation added

### DIFF
--- a/include/threads/synch.h
+++ b/include/threads/synch.h
@@ -3,6 +3,8 @@
 
 #include <list.h>
 #include <stdbool.h>
+#include <debug.h>
+
 
 /* A counting semaphore. */
 struct semaphore {
@@ -34,6 +36,7 @@ struct condition {
 };
 
 void cond_init (struct condition *);
+bool sema_priority_more (const struct list_elem *a_, const struct list_elem *b_, void *aux UNUSED);
 void cond_wait (struct condition *, struct lock *);
 void cond_signal (struct condition *, struct lock *);
 void cond_broadcast (struct condition *, struct lock *);

--- a/include/threads/synch.h
+++ b/include/threads/synch.h
@@ -22,6 +22,7 @@ void sema_self_test (void);
 struct lock {
 	struct thread *holder;      /* Thread holding lock (for debugging). */
 	struct semaphore semaphore; /* Binary semaphore controlling access. */
+	struct list_elem elem;
 };
 
 void lock_init (struct lock *);

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -91,12 +91,17 @@ struct thread {
 	enum thread_status status;          /* Thread state. */
 	char name[16];                      /* Name (for debugging purposes). */
 	int priority;                       /* Priority. */
+	int original_priority;				/* boost 이전의 priority */
 
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem;              /* List element. */
 
 	/* 깨어나야 할 틱 저장 */
 	int64_t wake_up_ticks;
+
+	/* Priority donation */
+	struct lock *waiting_lock;			/* 이 스레드가 사용을 기다리고 있는 락 */
+	struct list my_locks;				/* 이 스레드가 최초 요청한 락의 목록 */
 
 #ifdef USERPROG
 			/* Owned by userprog/process.c. */

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -127,7 +127,7 @@ typedef void thread_func (void *aux);
 tid_t thread_create (const char *name, int priority, thread_func *, void *);
 
 void thread_block (void);
-static bool priority_more (const struct list_elem *a_, const struct list_elem *b_, void *aux UNUSED);
+bool priority_more (const struct list_elem *a_, const struct list_elem *b_, void *aux UNUSED);
 void thread_unblock (struct thread *);
 
 struct thread *thread_current (void);

--- a/tests/threads/mlfqs/Make.tests
+++ b/tests/threads/mlfqs/Make.tests
@@ -19,4 +19,4 @@ tests/threads/mlfqs/mlfqs-nice-10.output		\
 tests/threads/mlfqs/mlfqs-block.output
 
 $(MLFQS_OUTPUTS): KERNELFLAGS += -mlfqs
-$(MLFQS_OUTPUTS): TIMEOUT = 1
+$(MLFQS_OUTPUTS): TIMEOUT = 480

--- a/tests/threads/mlfqs/Make.tests
+++ b/tests/threads/mlfqs/Make.tests
@@ -19,4 +19,4 @@ tests/threads/mlfqs/mlfqs-nice-10.output		\
 tests/threads/mlfqs/mlfqs-block.output
 
 $(MLFQS_OUTPUTS): KERNELFLAGS += -mlfqs
-$(MLFQS_OUTPUTS): TIMEOUT = 480
+$(MLFQS_OUTPUTS): TIMEOUT = 1

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -66,7 +66,7 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {
-		list_push_back (&sema->waiters, &thread_current ()->elem);
+		list_insert_ordered (&sema->waiters, &thread_current ()->elem, priority_more, NULL);
 		thread_block ();
 	}
 	sema->value--;
@@ -109,10 +109,12 @@ sema_up (struct semaphore *sema) {
 	ASSERT (sema != NULL);
 
 	old_level = intr_disable ();
-	if (!list_empty (&sema->waiters))
-		thread_unblock (list_entry (list_pop_front (&sema->waiters),
-					struct thread, elem));
+	if (!list_empty (&sema->waiters)) {
+		list_sort(&sema->waiters, priority_more, NULL);
+		thread_unblock (list_entry (list_pop_front (&sema->waiters), struct thread, elem));
+	}
 	sema->value++;
+	thread_yield();
 	intr_set_level (old_level);
 }
 
@@ -252,6 +254,17 @@ cond_init (struct condition *cond) {
 	list_init (&cond->waiters);
 }
 
+bool
+sema_priority_more (const struct list_elem *a_, const struct list_elem *b_, void *aux UNUSED) { 
+	const struct semaphore_elem *a = list_entry (a_, struct semaphore_elem, elem);
+	const struct semaphore_elem *b = list_entry (b_, struct semaphore_elem, elem);
+
+	const struct list *waiter_a = &(a->semaphore.waiters);
+	const struct list *waiter_b = &(b->semaphore.waiters);
+
+	return priority_more(list_begin(waiter_a), list_begin(waiter_b), NULL);
+}
+
 /* Atomically releases LOCK and waits for COND to be signaled by
    some other piece of code.  After COND is signaled, LOCK is
    reacquired before returning.  LOCK must be held before calling
@@ -282,7 +295,7 @@ cond_wait (struct condition *cond, struct lock *lock) {
 	ASSERT (lock_held_by_current_thread (lock));
 
 	sema_init (&waiter.semaphore, 0);
-	list_push_back (&cond->waiters, &waiter.elem);
+	list_insert_ordered (&cond->waiters, &waiter.elem, sema_priority_more, NULL);
 	lock_release (lock);
 	sema_down (&waiter.semaphore);
 	lock_acquire (lock);
@@ -302,9 +315,10 @@ cond_signal (struct condition *cond, struct lock *lock UNUSED) {
 	ASSERT (!intr_context ());
 	ASSERT (lock_held_by_current_thread (lock));
 
-	if (!list_empty (&cond->waiters))
-		sema_up (&list_entry (list_pop_front (&cond->waiters),
-					struct semaphore_elem, elem)->semaphore);
+	if (!list_empty (&cond->waiters)) {
+		list_sort(&cond->waiters, sema_priority_more, NULL);
+		sema_up (&list_entry (list_pop_front (&cond->waiters), struct semaphore_elem, elem)->semaphore);
+	}
 }
 
 /* Wakes up all threads, if any, waiting on COND (protected by

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -244,13 +244,13 @@ thread_block (void) {
 	schedule ();
 }
 
-static bool
+bool
 priority_more (const struct list_elem *a_, const struct list_elem *b_,
             void *aux UNUSED) { 
-  const struct thread *a = list_entry (a_, struct thread, elem);
-  const struct thread *b = list_entry (b_, struct thread, elem);
+	const struct thread *a = list_entry (a_, struct thread, elem);
+	const struct thread *b = list_entry (b_, struct thread, elem);
 
-  return a->priority > b->priority;
+	return a->priority > b->priority;
 }
 
 


### PR DESCRIPTION
1. thread 구조체에 3개의 field를 추가했습니다: `original_priority`, `waiting_lock`, `my_locks`.
   - original_priority: **상속 이전의 priority**입니다. 상속 이후 이전 priority 복구에 사용됩니다.
   - waiting_lock: 해당 스레드가 사용하기 위해 기다리고 있는 **lock**입니다.
   - my_locks: 해당 스레드가 최초 요청해 가지고 있는 **lock의 목록**입니다.

2. thread.c의 `init_thread()` 함수를 수정했습니다. `original_priority`, `my_locks`를 초기화합니다.

3. thread.c의 `thread_set_priority()` 함수를 수정했습니다. priority 수정 시 `original_priority`를 이용해 donation 여부를 체크합니다.

4. synch.c의 `lock_acquire()`, `lock_release()` 함수를 수정했습니다.

   - lock_acquire()

     ```python
     def lock_acquire(*lock):
       ...
       if (lock이 점유):
         cur->waiting_lock = lock
         while (lock):
           if (lock.holder->priority가 현재보다 낮으면): 현재 priority로 덮어씌움
           lock = lock->holder->lock
     	my_locks.append(lock)
     ```

   - lock_release()

     ```python
     def lock_release(*lock):
       my_locks.remove(lock)
       new_priority = 원래priority
       if (my_locks 있으면):
     		for lock in locks:
           ...
           new_priority = waiters중에서 제일 높은 priority
       cur->priority = new_priority		# original이거나 highest거나 둘 중 하나
     ```
